### PR TITLE
i3: make keyboard layout custom options permanent

### DIFF
--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -1,0 +1,1 @@
+README.md

--- a/i3/.config/i3/config
+++ b/i3/.config/i3/config
@@ -6,7 +6,7 @@ set $alt Mod1
 font pango:monospace Mono 10
 
 # autostart
-exec_always --no-startup-id setxkbmap -layout de && xmodmap -e "clear lock" && xmodmap -e "keycode 0x42 = Escape"
+#exec_always --no-startup-id setxkbmap -layout de -option caps:escape
 exec --no-startup-id picom -b
 exec --no-startup-id dunst
 exec --no-startup-id feh --bg-fill ~/dev/dotfiles/wallpaper/nebula.png

--- a/i3/README.md
+++ b/i3/README.md
@@ -1,0 +1,11 @@
+To configure X11 keyboard layout edit: `/etc/X11/xorg.conf.d/00-keyboard.conf`
+
+```
+Section "InputClass"
+        Identifier "system-keyboard"
+        MatchIsKeyboard "on"
+        Option "XkbLayout" "de"
+        Option "XkbModel" "pc105"
+        Option "XkbOptions" "caps:escape"
+EndSection
+```


### PR DESCRIPTION
use global config file instead of setxkbmap